### PR TITLE
Tweaks for latest rust and clippy

### DIFF
--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -23,7 +23,7 @@ impl EventSinkFormat {
     pub fn create_from_file<P>(path_arg: P) -> Result<EventSinkFormat, Box<dyn Error>> 
         where P: AsRef<Path>
     {
-        let path = path_arg.as_ref().clone();
+        let path = path_arg.as_ref();
         if Some(OsStr::new("jsonl")) == path.extension() {
             Ok(EventSinkFormat::JSONL(path.to_path_buf()))
         }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -17,9 +17,7 @@ impl Ord for Signature {
 
 impl PartialOrd for Signature {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-         let self_s = self.normalised_string();
-         let other_s = other.normalised_string();
-         self_s.partial_cmp(&other_s)
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
tweaks for:

```
cargo --version --verbose
cargo 1.73.0 (9c4383fb5 2023-08-26)
release: 1.73.0
commit-hash: 9c4383fb55986096b414d98125421ab87b5fd642
commit-date: 2023-08-26
host: aarch64-apple-darwin
libgit2: 1.6.4 (sys:0.17.2 vendored)
libcurl: 8.1.2 (sys:0.4.65+curl-8.2.1 system ssl:(SecureTransport) LibreSSL/3.3.6)
ssl: OpenSSL 1.1.1u  30 May 2023
os: Mac OS 14.1.0 [64-bit]
```